### PR TITLE
fix(flatcover): respect registry URL path when fetching packages

### DIFF
--- a/bin/flatcover.js
+++ b/bin/flatcover.js
@@ -189,7 +189,8 @@ async function* checkCoverage(deps, { registry, auth, token, progress }) {
     const results = await Promise.all(
       batch.map(async ([name, versions]) => {
         const encodedName = encodePackageName(name);
-        const path = `/${encodedName}`;
+        const basePath = baseUrl.pathname.replace(/\/$/, '');
+        const path = `${basePath}/${encodedName}`;
 
         try {
           const response = await client.request({


### PR DESCRIPTION
Registry URLs with base paths (e.g., https://libraries.cgr.dev/javascript) were incorrectly stripped to just the origin, causing 403 errors when the auth credentials were valid but requests went to the wrong endpoint.