### PR TITLE
refactor(ci) clean up ncc release process

### DIFF
--- a/.github/workflows/ncc-release.yaml
+++ b/.github/workflows/ncc-release.yaml
@@ -25,6 +25,9 @@ jobs:
           - os: ubuntu-latest
             platform: linux
             arch: x64
+          - os: ubuntu-24.04-arm
+            platform: linux
+            arch: arm64
           - os: macos-15
             platform: darwin
             arch: arm64
@@ -33,18 +36,13 @@ jobs:
       contents: read
 
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@df199fb7be9f65074067a9eb93f12bb4c5547cf2 # v2.13.3
-        with:
-          egress-policy: audit
-
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
 
       - name: Setup pnpm
-        uses: step-security/action-setup@3d419c73e38e670dbffe349ffff26dd13c164640 # v4.2.0
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
         with:
           version: '10'
 
@@ -86,11 +84,6 @@ jobs:
       contents: write
 
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@df199fb7be9f65074067a9eb93f12bb4c5547cf2 # v2.13.3
-        with:
-          egress-policy: audit
-
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
@@ -114,8 +107,10 @@ jobs:
           generate_release_notes: true
           files: |
             binaries/flatlock-linux-x64
+            binaries/flatlock-linux-arm64
             binaries/flatlock-darwin-arm64
             binaries/flatcover-linux-x64
+            binaries/flatcover-linux-arm64
             binaries/flatcover-darwin-arm64
           body: |
             ## flatlock v${{ inputs.version }}
@@ -137,6 +132,12 @@ jobs:
             # Linux (x64)
             curl -L -o flatlock https://github.com/${{ github.repository }}/releases/download/v${{ inputs.version }}/flatlock-linux-x64
             curl -L -o flatcover https://github.com/${{ github.repository }}/releases/download/v${{ inputs.version }}/flatcover-linux-x64
+            chmod +x flatlock flatcover
+            mv flatlock flatcover /usr/local/bin/
+
+            # Linux (ARM64)
+            curl -L -o flatlock https://github.com/${{ github.repository }}/releases/download/v${{ inputs.version }}/flatlock-linux-arm64
+            curl -L -o flatcover https://github.com/${{ github.repository }}/releases/download/v${{ inputs.version }}/flatcover-linux-arm64
             chmod +x flatlock flatcover
             mv flatlock flatcover /usr/local/bin/
 


### PR DESCRIPTION
This PR does the following:

- [x] Uses open source versions pinned at a specific commit
- [x] Adds linux arm as a target