### PR TITLE
release(ncc) clean up our ncc process through iteration

### DIFF
--- a/.github/workflows/ncc-release.yaml
+++ b/.github/workflows/ncc-release.yaml
@@ -43,8 +43,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
-        with:
-          version: '10'
 
       - name: Setup Node.js
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0


### PR DESCRIPTION
This PR does the following:

- [x] Run on `ubuntu-24.04-arm`
- [x] Use pinned open source runners
- [x] Remove invalid `version: '10'`