### PR TITLE
bench(flatlock-cmp) use console.time to measure parse performance

### DIFF
--- a/bin/flatlock-cmp.js
+++ b/bin/flatlock-cmp.js
@@ -187,7 +187,7 @@ Examples:
         const wsNote = result.workspaceCount > 0 ? ` (${result.workspaceCount} workspaces excluded)` : '';
         console.log(`✓  ${result.path}${wsNote}`);
         console.log(`   count: flatlock=${result.flatlockCount} ${result.source}=${result.comparisonCount}`);
-        console.log(`   sets:  equinumerous`);
+        console.log(`   sets:  equinumerous\n`);
       }
     } else {
       // Determine if this is a "superset" (flatlock found more, expected for pnpm)
@@ -203,7 +203,7 @@ Examples:
           console.log(`⊃  ${result.path}${wsNote}`);
           console.log(`   count: flatlock=${result.flatlockCount} ${result.source}=${result.comparisonCount}`);
           console.log(`   sets:  SUPERSET (+${result.onlyInFlatlock.length} reachable deps)`);
-          console.log(`   note:  flatlock's reachability analysis found transitive deps pnpm omits`);
+          console.log(`   note:  flatlock's reachability analysis found transitive deps pnpm omits\n`);
         }
       } else {
         mismatchCount++;


### PR DESCRIPTION
Uses `flatlock.collect` instead of `flatlock.fromPath` in `bin/flatlock-cmp.js` to measure the parse timing in isolation from `flatlockSet.add(spec)`

Sample output:

```
⏱  collect [...]-pnpm-lock.yaml: 18.113ms
⊃  [...]-pnpm-lock.yaml
   count: flatlock=1355 js-yaml=1349
   sets:  SUPERSET (+6 reachable deps)
   note:  flatlock's reachability analysis found transitive deps pnpm omits

⏱  collect [...]/package-lock.json: 3.593ms
✓  [...]/package-lock.json (4 workspaces excluded)
   count: flatlock=1434 @npmcli/arborist=1434
   sets:  equinumerous
```