### PR TITLE
fix(release) remove v prefix from release tags

### DIFF
--- a/.github/workflows/ncc-release.yaml
+++ b/.github/workflows/ncc-release.yaml
@@ -1,6 +1,6 @@
 name: flatlock-release
 run-name: >
-  (#${{ github.run_number }}) flatlock release v${{ inputs.version }}
+  (#${{ github.run_number }}) flatlock release ${{ inputs.version }}
 
 on:
   workflow_dispatch:
@@ -99,8 +99,8 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
         with:
-          tag_name: v${{ inputs.version }}
-          name: flatlock v${{ inputs.version }}
+          tag_name: ${{ inputs.version }}
+          name: flatlock ${{ inputs.version }}
           prerelease: ${{ inputs.prerelease }}
           generate_release_notes: true
           files: |
@@ -111,7 +111,7 @@ jobs:
             binaries/flatcover-linux-arm64
             binaries/flatcover-darwin-arm64
           body: |
-            ## flatlock v${{ inputs.version }}
+            ## flatlock ${{ inputs.version }}
 
             The Matlock of lockfile parsers - extracts packages without building dependency graphs.
 
@@ -128,20 +128,20 @@ jobs:
 
             ```bash
             # Linux (x64)
-            curl -L -o flatlock https://github.com/${{ github.repository }}/releases/download/v${{ inputs.version }}/flatlock-linux-x64
-            curl -L -o flatcover https://github.com/${{ github.repository }}/releases/download/v${{ inputs.version }}/flatcover-linux-x64
+            curl -L -o flatlock https://github.com/${{ github.repository }}/releases/download/${{ inputs.version }}/flatlock-linux-x64
+            curl -L -o flatcover https://github.com/${{ github.repository }}/releases/download/${{ inputs.version }}/flatcover-linux-x64
             chmod +x flatlock flatcover
             mv flatlock flatcover /usr/local/bin/
 
             # Linux (ARM64)
-            curl -L -o flatlock https://github.com/${{ github.repository }}/releases/download/v${{ inputs.version }}/flatlock-linux-arm64
-            curl -L -o flatcover https://github.com/${{ github.repository }}/releases/download/v${{ inputs.version }}/flatcover-linux-arm64
+            curl -L -o flatlock https://github.com/${{ github.repository }}/releases/download/${{ inputs.version }}/flatlock-linux-arm64
+            curl -L -o flatcover https://github.com/${{ github.repository }}/releases/download/${{ inputs.version }}/flatcover-linux-arm64
             chmod +x flatlock flatcover
             mv flatlock flatcover /usr/local/bin/
 
             # macOS (Apple Silicon)
-            curl -L -o flatlock https://github.com/${{ github.repository }}/releases/download/v${{ inputs.version }}/flatlock-darwin-arm64
-            curl -L -o flatcover https://github.com/${{ github.repository }}/releases/download/v${{ inputs.version }}/flatcover-darwin-arm64
+            curl -L -o flatlock https://github.com/${{ github.repository }}/releases/download/${{ inputs.version }}/flatlock-darwin-arm64
+            curl -L -o flatcover https://github.com/${{ github.repository }}/releases/download/${{ inputs.version }}/flatcover-darwin-arm64
             chmod +x flatlock flatcover
             mv flatlock flatcover /usr/local/bin/
             ```


### PR DESCRIPTION
Drop the `v` prefix from `tag_name`, release name, and download URLs in the release workflow

Existing draft releases (`v1.3.0`, `v1.4.0`) have been re-tagged and published

There is nothing in the semver spec about a `v` prefix. It was never part of the version. It was just sitting there, consuming a byte, adding no information. Now it's gone.

See also: [_"Is “v1.2.3” a semantic version?"_](https://semver.org/#is-v123-a-semantic-version) (spoiler: no, it's not)
