### PR TITLE
fix(release) skip npm auth pre-check for OIDC trusted publishing

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -8,7 +8,8 @@
   },
   "npm": {
     "publish": true,
-    "provenance": true
+    "provenance": true,
+    "skipChecks": true
   },
   "github": {
     "release": false


### PR DESCRIPTION
## What

Adds `"skipChecks": true` to the `npm` section of `.release-it.json`.

## Why

release-it runs `npm whoami` as a pre-flight check before publishing. Under OIDC trusted publishing, no static auth token exists — the token is generated during `npm publish --provenance` via the GitHub Actions OIDC provider. The pre-check fails because it runs before the token exchange happens. Skipping it lets the publish step handle authentication at the right time.

## Risk Assessment

**Low risk.** Single config addition. The npm registry still validates credentials during the actual publish step.

## References

- refs #21
