### PR TITLE
fix(release) use Node 24 and empty NODE_AUTH_TOKEN for OIDC publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
 
@@ -44,3 +44,4 @@ jobs:
         run: pnpm exec release-it --ci --increment ${{ inputs.increment }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ''


### PR DESCRIPTION
## What

Switches the release workflow from Node 22 to Node 24 and sets `NODE_AUTH_TOKEN` to an empty string in the release step.

## Why

npm OIDC trusted publishing requires npm >= 11.5.0. Node 22 ships with npm 10.x, while Node 24 ships with npm 11.x which has OIDC support built in. The empty `NODE_AUTH_TOKEN` prevents the `.npmrc` template (created by `setup-node` with `registry-url`) from interfering with the OIDC token exchange that happens during `npm publish --provenance`.

## Risk Assessment

**Low risk.** Node 24 is already tested in CI. The release workflow only runs on manual dispatch.

## References

- refs #23
- [Working release-it + OIDC example](https://github.com/nickradford/ashiba/blob/0800291/.github/workflows/release.yml)