### PR TITLE
fix(release) configure git identity for release commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,11 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
 
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## What

Adds a `git config` step to the release workflow that sets the committer identity to `github-actions[bot]`.

## Why

release-it commits the version bump and changelog update back to `main`. The GitHub Actions runner has no default git identity, so `git commit` fails with "Author identity unknown". The `github-actions[bot]` identity is the standard convention for CI-authored commits.

## Risk Assessment

**Low risk.** Additive step in the release workflow. Does not affect the publish or tagging logic.